### PR TITLE
First Class Content using a content dictionary

### DIFF
--- a/models/coreschema.js
+++ b/models/coreschema.js
@@ -61,7 +61,7 @@ User.set('toJSON', {
 
 var Page = new Schema({
     id: {type: String, required: true},
-    content: {type: String, ref: 'Content'},
+    contentRef: {type: String, required: true},
     name: {type: String, required: true},
     pageTransition: {type: String, required: true},
     conditions: [{type: String, ref: 'Schema.Types.Mixed'}],
@@ -73,6 +73,14 @@ var Page = new Schema({
         },
         required: true
     }
+});
+
+Page.virtual("content").get(function() {
+  return this.ownerDocument().content[this.contentRef] || "";
+});
+
+Page.set("toJSON", {
+   virtuals: true
 });
 
 // Location -------------------------------------------------------------------
@@ -97,19 +105,12 @@ var Function = new Schema({
     conditions: [{type: String, ref: 'Condition'}],
 });
 
-// Content --------------------------------------------------------------------
-
-var Content = new Schema({
-    name: String,
-    body: String
-});
-
 // Story ----------------------------------------------------------------------
 
 var Story = new Schema({
     name: {type: String, required: true},
     pages: [Page],
-    content: [Content],
+    content: {},
     locations: [Location],
     conditions: [Schema.Types.Mixed],
     functions: [Function],

--- a/models/coreschema.js
+++ b/models/coreschema.js
@@ -61,7 +61,7 @@ User.set('toJSON', {
 
 var Page = new Schema({
     id: {type: String, required: true},
-    content: {type: String},
+    content: {type: String, ref: 'Content'},
     name: {type: String, required: true},
     pageTransition: {type: String, required: true},
     conditions: [{type: String, ref: 'Schema.Types.Mixed'}],
@@ -97,12 +97,19 @@ var Function = new Schema({
     conditions: [{type: String, ref: 'Condition'}],
 });
 
+// Content --------------------------------------------------------------------
+
+var Content = new Schema({
+    name: String,
+    body: String
+});
 
 // Story ----------------------------------------------------------------------
 
 var Story = new Schema({
     name: {type: String, required: true},
     pages: [Page],
+    content: [Content],
     locations: [Location],
     conditions: [Schema.Types.Mixed],
     functions: [Function],


### PR DESCRIPTION
This implements server-side first class content without requiring client-side changes. 

It uses a virtual 'content' property, whose getter looks up the actual content in the Story document's 'content' dictionary and returns that. The 'contentRef' property stores the name of the content.

Another approach available at https://github.com/Spoffy/StoryplacesServer/tree/first_class_content_map replaces the content later on in the Story controller - but it's a less clean approach.

This is paired with the schema-conversion branch https://github.com/Spoffy/schema-conversion/tree/first_class_content_map , which upgrades from V2 schemas to a draft V3 schema that has first class content.